### PR TITLE
Assume MLJ user provides matrix input in form n x p

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MLJModelInterface = "0.3"
@@ -22,6 +21,7 @@ julia = "1"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase"]
+test = ["MLJBase", "Test"]

--- a/src/MulticlassPerceptronCore.jl
+++ b/src/MulticlassPerceptronCore.jl
@@ -1,7 +1,6 @@
-
 # using MetadataTools,  DocStringExtensions
 using Random: shuffle, MersenneTwister
-using LinearAlgebra: mul!
+using LinearAlgebra: mul!, Adjoint
 
 using StatsBase
 #import StatsBase: fit!, predict
@@ -175,6 +174,12 @@ function fit!(h::MulticlassPerceptronCore,
               seed=MersenneTwister(1234),
               f_shuffle_data=false)
 
+    if X isa Adjoint && verbosity > 0
+        @info "Core multiclass perceptron algorithm receiving features as an "*
+            "adjoint matrix. Providing feature matrix in the form "*
+            "permtutedims(A)'` for some matrix `A` may improve "*
+            "performance. "
+    end
 
     n_features, n_observations = size(X)
 

--- a/src/mlj/interface.jl
+++ b/src/mlj/interface.jl
@@ -62,7 +62,7 @@ end
 # matrices; the output of these methods is an abstract array with
 # features as rows:
 _reformat(X) = MLJModelInterface.matrix(X, transpose=true) # fallback is table
-_reformat(X, ::Type{<:AbstractMatrix}) = X' 
+_reformat(X::AbstractMatrix) = X'
 
 function MLJModelInterface.fit(model::MulticlassPerceptronClassifier,
                      verbosity::Int,

--- a/src/mlj/interface.jl
+++ b/src/mlj/interface.jl
@@ -58,9 +58,11 @@ function MLJModelInterface.clean!(model::MulticlassPerceptronClassifier)
     return warning
 end
 
-# front end for incoming features, which can only be tables or matrices
+# front end for incoming features, which can only be tables or
+# matrices; the output of these methods is an abstract array with
+# features as rows:
 _reformat(X) = MLJModelInterface.matrix(X, transpose=true) # fallback is table
-_reformat(X, ::Type{<:AbstractMatrix}) = X
+_reformat(X, ::Type{<:AbstractMatrix}) = X' 
 
 function MLJModelInterface.fit(model::MulticlassPerceptronClassifier,
                      verbosity::Int,

--- a/test/interface/fitpredict.jl
+++ b/test/interface/fitpredict.jl
@@ -1,3 +1,7 @@
+#########################################################
+# WARNING: THIS FILE IS NOT CURRENTLY INCLUDED IN TESTS #
+#########################################################
+
 using Test
 using Random
 using MLJBase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ end
             "MulticlassPerceptron.MulticlassPerceptronClassifier"
 
         fitresult, = MLJBase.fit(perceptron, verbosity, X, y)
-        ŷ          = predict(perceptron, fitresult, X) 
+        ŷ          = predict(perceptron, fitresult, X)
 
         @test length(ŷ)==length(y)
     end
@@ -59,16 +59,31 @@ end
     @testset "n=100, p=10, n_classes=3" begin
         Random.seed!(6161)
         n, p, n_classes, verbosity = 100, 10, 3, 0
-        X = randn(n, p)
+        A = randn(n, p)
         y = CategoricalArray(rand(1:n_classes, n))
 
-        X = MLJBase.table(X)
+        X = MLJBase.table(A)
         perceptron = MulticlassPerceptronClassifier(n_epochs=10;
                                                 f_average_weights=true)
+        Random.seed!(1234)
         fitresult, = MLJBase.fit(perceptron, verbosity, X, y)
         ŷ          = predict(perceptron, fitresult, X)
 
         @test length(ŷ)==length(y)
+
+        # MLJ user has provided an n x p matrix (raw):
+        Random.seed!(1234)
+        fitresult, = MLJBase.fit(perceptron, verbosity, A, y)
+        ŷ2          = predict(perceptron, fitresult, A)
+        @test ŷ2 == ŷ
+
+        # MLJ user has provided an n x p matrix (adjoint of a p x n):
+        B = permutedims(A)'
+        Random.seed!(1234)
+        fitresult, = MLJBase.fit(perceptron, verbosity, B, y)
+        ŷ3          = predict(perceptron, fitresult, B)
+        @test ŷ3 == ŷ
+
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,14 +73,17 @@ end
 
         # MLJ user has provided an n x p matrix (raw):
         Random.seed!(1234)
-        fitresult, = MLJBase.fit(perceptron, verbosity, A, y)
+        # should get "warning" that performance is not optimal:
+        fitresult, = @test_logs((:info, r"Core multiclass"),
+                                MLJBase.fit(perceptron, 1, A, y))
         ŷ2          = predict(perceptron, fitresult, A)
         @test ŷ2 == ŷ
 
         # MLJ user has provided an n x p matrix (adjoint of a p x n):
         B = permutedims(A)'
         Random.seed!(1234)
-        fitresult, = MLJBase.fit(perceptron, verbosity, B, y)
+        # should not get any extra logging:
+        fitresult, = @test_logs MLJBase.fit(perceptron, 1, B, y)
         ŷ3          = predict(perceptron, fitresult, B)
         @test ŷ3 == ŷ
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,8 +51,7 @@ end
             "MulticlassPerceptron.MulticlassPerceptronClassifier"
 
         fitresult, = MLJBase.fit(perceptron, verbosity, X, y)
-        # ŷ          = predict(perceptron, fitresult, X) # Do we really want this API?
-        ŷ          = predict(fitresult, X) # Why not simpy this?
+        ŷ          = predict(perceptron, fitresult, X) 
 
         @test length(ŷ)==length(y)
     end
@@ -67,8 +66,7 @@ end
         perceptron = MulticlassPerceptronClassifier(n_epochs=10;
                                                 f_average_weights=true)
         fitresult, = MLJBase.fit(perceptron, verbosity, X, y)
-        #ŷ          = predict(perceptron, fitresult, X) # Do we really want this API?
-        ŷ          = predict(fitresult, X) # Why not simpy this?
+        ŷ          = predict(perceptron, fitresult, X)
 
         @test length(ŷ)==length(y)
     end


### PR DESCRIPTION
This PR does this:

- fixes `_reformat` so that MLJ user provides matrix input in form n x p (currently user must provide a features-as-columnns table or p x n matrix) (#5)

- in case MLJ user does not provide an adjoint, they are informed that performance is not optimal and a remedy is suggested

- restores some invalid MLJ interface tests (as [here](https://github.com/davidbp/MulticlassPerceptron.jl/blob/e05bd7c8f8cfa392bd470c31d294df9bf6909308/test/runtests.jl#L54)): The signature of MLJ model `predict` method (as opposed to machine `predict`) is `predict(model, fitresult, X)` not `predict(fitresult, X)`; see https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#The-predict-method-1. 

